### PR TITLE
Tweak I needed to compile jBLAS to use OpenBLAS

### DIFF
--- a/config/config_libs.rb
+++ b/config/config_libs.rb
@@ -69,7 +69,7 @@ LAPACK_REQUIRED_SYMBOLS = [ 'dsyev_', 'daxpy_', 'dgemm_' ]
 
 ATLAS_LIBS = %w(lapack lapack_fortran lapack_atlas f77blas cblas atlas)
 PT_ATLAS_LIBS = %w(lapack lapack_fortran lapack_atlas ptf77blas ptcblas atlas)
-LAPACK_LIBS = %w(lapack_fortran lapack blas_fortran blas)
+LAPACK_LIBS = %w(lapack_fortran lapack blas_fortran blas openblas)
 
 configure :libs => 'LOADLIBES'
 


### PR DESCRIPTION
Hello Dr. Braun,

Thanks for your work on jBLAS - it's very handy. I needed to make the following small change to compile jBLAS against my OpenBLAS install. I don't know if it's universally useful, but I figured I'd pass it along just in case.

Thanks,
Ryan Gabbard