### PR TITLE
Add support for openblas

### DIFF
--- a/config/config_libs.rb
+++ b/config/config_libs.rb
@@ -69,7 +69,7 @@ LAPACK_REQUIRED_SYMBOLS = [ 'dsyev_', 'daxpy_', 'dgemm_' ]
 
 ATLAS_LIBS = %w(lapack lapack_fortran lapack_atlas f77blas cblas atlas)
 PT_ATLAS_LIBS = %w(lapack lapack_fortran lapack_atlas ptf77blas ptcblas atlas)
-LAPACK_LIBS = %w(lapack_fortran lapack blas_fortran blas)
+LAPACK_LIBS = %w(lapack_fortran lapack blas_fortran blas openblas)
 
 configure :libs => 'LOADLIBES'
 


### PR DESCRIPTION
This change adds support for openblas - works if you build openblas and install with
make install PREFIX=/root/openblas 

Then configure jblas like so:
./configure --static-libs --libpath="/root/openblas/lib"  --download-lapack --lapack-build

cc @shivaram