### PR TITLE
temp files existance check fix

### DIFF
--- a/src/main/java/org/jblas/util/LibraryLoader.java
+++ b/src/main/java/org/jblas/util/LibraryLoader.java
@@ -203,23 +203,25 @@ public class LibraryLoader {
   private void loadLibraryFromStream(String libname, InputStream is) {
     try {
       File tempfile = createTempFile(libname);
-      OutputStream os = new FileOutputStream(tempfile);
+      if (!tempfile.exists()){ 
+        OutputStream os = new FileOutputStream(tempfile);
 
-      logger.debug("tempfile.getPath() = " + tempfile.getPath());
+        logger.debug("tempfile.getPath() = " + tempfile.getPath());
 
-      long savedTime = System.currentTimeMillis();
+        long savedTime = System.currentTimeMillis();
 
-      // Leo says 8k block size is STANDARD ;)
-      byte buf[] = new byte[8192];
-      int len;
-      while ((len = is.read(buf)) > 0) {
-        os.write(buf, 0, len);
+        // Leo says 8k block size is STANDARD ;)
+        byte buf[] = new byte[8192];
+        int len;
+        while ((len = is.read(buf)) > 0) {
+          os.write(buf, 0, len);
+        }
+
+        double seconds = (double) (System.currentTimeMillis() - savedTime) / 1e3;
+        logger.debug("Copying took " + seconds + " seconds.");
+
+        os.close();
       }
-
-      double seconds = (double) (System.currentTimeMillis() - savedTime) / 1e3;
-      logger.debug("Copying took " + seconds + " seconds.");
-
-      os.close();
 
       logger.debug("Loading library from " + tempfile.getPath() + ".");
       System.load(tempfile.getPath());


### PR DESCRIPTION
Have a look, this is the solution for issue 59
https://github.com/mikiobraun/jblas/issues/59

The problem was in fact that because OutputStream tries to create same file with same name on each start of jblas, even if file is already there, jblass fails to start in more than 1 instance of the JVM process. It is not necessery, I think.

With this patch I am able to run several instances of jblas at the same time on my Win7 machine.
Also, I noticed you used Shutdown hook for deleting files, I think same job could be achieved more easily with java File.deleteOnExit() method. (I didn't touch that code)

cheers 