### PR TITLE
For Java 9: use -source/-target 1.6 as 1.5 is unsupported

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -126,12 +126,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <mkdir dir="${bin}" />
     </target>
     <target name="compile" depends="prepare,generate-float" description="compile java code">
-        <javac destdir="${bin}" encoding="utf-8" source="1.5" debug="on" compiler="javac1.5" target="1.5" fork="yes" nowarn="yes">
+        <javac destdir="${bin}" encoding="utf-8" source="1.6" debug="on" compiler="javac1.5" target="1.6" fork="yes" nowarn="yes">
             <src path="${src}" />
         </javac>
     </target>
     <target name="compile-test" depends="compile" description="compile java test code">
-        <javac destdir="${bin}" encoding="utf-8" source="1.5" debug="on" compiler="javac1.5" target="1.5" fork="yes" nowarn="yes">
+        <javac destdir="${bin}" encoding="utf-8" source="1.6" debug="on" compiler="javac1.5" target="1.6" fork="yes" nowarn="yes">
             <src path="${test}" />
             <classpath>
                 <pathelement location="${external}/junit-4.8.2.jar" />
@@ -139,7 +139,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         </javac>
     </target>
     <target name="javah" depends="prepare" description="run javah">
-        <javac destdir="${bin}" encoding="utf-8" source="1.5" debug="on" compiler="javac1.5" target="1.5" fork="yes" nowarn="yes">
+        <javac destdir="${bin}" encoding="utf-8" source="1.6" debug="on" compiler="javac1.5" target="1.6" fork="yes" nowarn="yes">
             <src path="${src}" />
             <include name="**/NativeBlas.java" />
             <include name="**/ArchFlavor.java" />

--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.3.2</version>
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.6</source>
+          <target>1.6</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Java 9 will be released in about 28 days. It no longer supports the `-source 1.5`, argument, the minimum is 1.6. After fixing this, and working around #89, the build succeeds on the current Java 9 builds.