### PR TITLE
org.jblas.TestDoubleMatrix::testColumnAndRowMinMax has inadequate loop coverage

### DIFF
--- a/src/test/java/org/jblas/TestDoubleMatrix.java
+++ b/src/test/java/org/jblas/TestDoubleMatrix.java
@@ -667,6 +667,30 @@ public class TestDoubleMatrix extends AbstractTestJblas {
   }
 
   @Test
+  public void testColumnAndRowMinMaxUnsorted() {
+    assertEquals(new DoubleMatrix(1, 3, -2.0, -6.0, -8.0), E.columnMins());
+    assertEquals(new DoubleMatrix(3, 1, -4.0, -8.0, -6.0), E.rowMins());
+    assertEquals(new DoubleMatrix(1, 3, 3.0, 5.0, 9.0), E.columnMaxs());
+    assertEquals(new DoubleMatrix(3, 1, 7.0, 5.0, 9.0), E.rowMaxs());
+    int[] i = E.columnArgmins();
+    assertEquals(1, i[0]);
+    assertEquals(2, i[1]);
+    assertEquals(1, i[2]);
+    i = E.columnArgmaxs();
+    assertEquals(2, i[0]);
+    assertEquals(1, i[1]);
+    assertEquals(2, i[2]);
+    i = E.rowArgmins();
+    assertEquals(1, i[0]);
+    assertEquals(2, i[1]);
+    assertEquals(1, i[2]);
+    i = E.rowArgmaxs();
+    assertEquals(2, i[0]);
+    assertEquals(1, i[1]);
+    assertEquals(2, i[2]);
+  }
+
+  @Test
   public void testToArray() {
     assertTrue(Arrays.equals(new double[]{2.0, 4.0, 8.0}, B.toArray()));
     assertTrue(Arrays.equals(new int[]{2, 4, 8}, B.toIntArray()));


### PR DESCRIPTION
Currently, `org.jblas.TestDoubleMatrix::testColumnAndRowMinMax()` only exercises the loop in `org.jblas.DoubleMatrix::argmin()` such that the the element at index 0 is always returned as the min, although there is no specification for an input array that is sorted in ascending order. Similar argument for the other min functions in that test case. This PR adds `org.jblas.TestDoubleMatrix::testColumnAndRowMinMaxUnsorted()` to increase [loop coverage](http://www.bullseye.com/coverage.html#other_loop), and find the min when the input array is unsorted.